### PR TITLE
Fixed Combo Box list sometimes being render under components

### DIFF
--- a/vibrant/components/studio/StudioDockWidgetGui.lua
+++ b/vibrant/components/studio/StudioDockWidgetGui.lua
@@ -4,6 +4,7 @@ local e = Roact.createElement
 
 local Dictionary = require(script.Parent.Parent.Parent.utils.Dictionary)
 local StudioPluginContext = require(script.Parent.StudioPluginContext)
+local StudioDockWidgetGuiContext = require(script.Parent.StudioDockWidgetGuiContext)
 
 -----------------------------------------------------------------------------
 
@@ -46,9 +47,9 @@ function StudioDockWidgetGui:init()
 end
 
 function StudioDockWidgetGui:render()
-    return e(Roact.Portal, {
-        target = self.dockWidget
-    }, self.props[Roact.Children])
+    return e(StudioDockWidgetGuiContext.Provider, { value = self.dockWidget }, {
+        e(Roact.Portal, { target = self.dockWidget }, self.props[Roact.Children])
+    })
 end
 
 function StudioDockWidgetGui:didUpdate(lastProps)

--- a/vibrant/components/studio/StudioDockWidgetGuiContext.lua
+++ b/vibrant/components/studio/StudioDockWidgetGuiContext.lua
@@ -1,0 +1,6 @@
+local Dependencies = require(script.Parent.Parent.Parent.DependencyPaths)
+local Roact = require(Dependencies.Roact)
+
+local StudioDockWidgetGuiContext = Roact.createContext(nil)
+
+return StudioDockWidgetGuiContext

--- a/vibrant/components/ui/ComboBox/OptionsList.lua
+++ b/vibrant/components/ui/ComboBox/OptionsList.lua
@@ -81,13 +81,17 @@ function ComboBoxOptionsList:render()
         optionsList = {
             BackgroundColor3 = self.props.backgroundColor,
             BorderSizePixel = 0,
-            Position = UDim2.new(0, 0, 1, 0),
-            Size = UDim2.new(1, 0, math.clamp(#self.props.options, 1, 8)),
+            Position = self.props.position,
             Visible = self.props.visible,
             ScrollingDirection = Enum.ScrollingDirection.Y,
             ScrollBarImageColor3 = self.props.scrollBarColor,
             VerticalScrollBarInset = Enum.ScrollBarInset.ScrollBar,
-            CanvasSize = UDim2.new(0, 0, 0, 0)
+            CanvasSize = UDim2.new(0, 0, 0, 0),
+            ZIndex = 9999999,
+
+            Size = self.props.size:map(function(absoluteSize)
+                return UDim2.new(0, absoluteSize.X, 0, absoluteSize.Y *  math.clamp(#self.props.options, 1, 8))
+            end)
         },
 
         optionContainer = {
@@ -95,8 +99,8 @@ function ComboBoxOptionsList:render()
             BorderSizePixel = 0,
             BackgroundTransparency = 1,
 
-            Size = self.props.comboBoxSizeBinding:map(function(comboBoxHeight)
-                return UDim2.new(1, 0, 0, comboBoxHeight)
+            Size = self.props.size:map(function(absoluteSize)
+                return UDim2.new(1, 0, 0, absoluteSize.Y)
             end),
 
             [Roact.Change.AbsoluteSize] = self.onOptionComponentSizeChanged,

--- a/vibrant/components/ui/ComboBox/OptionsList.lua
+++ b/vibrant/components/ui/ComboBox/OptionsList.lua
@@ -87,7 +87,7 @@ function ComboBoxOptionsList:render()
             ScrollBarImageColor3 = self.props.scrollBarColor,
             VerticalScrollBarInset = Enum.ScrollBarInset.ScrollBar,
             CanvasSize = UDim2.new(0, 0, 0, 0),
-            ZIndex = 9999999,
+            ZIndex = self.props.zIndex,
 
             Size = self.props.size:map(function(absoluteSize)
                 return UDim2.new(0, absoluteSize.X, 0, absoluteSize.Y *  math.clamp(#self.props.options, 1, 8))

--- a/vibrant/components/ui/ComboBox/init.lua
+++ b/vibrant/components/ui/ComboBox/init.lua
@@ -237,6 +237,15 @@ function ComboBox:render()
 
     local optionsContent = nil
     if self.state.isListOpen then
+        -- Calculate the highest Z-Index
+        local highestZIndex = 0
+        for _, child in ipairs(self.props.dockWidget:GetChildren()) do
+            if child:IsA("GuiObject") and child.ZIndex > highestZIndex then
+                highestZIndex = child.ZIndex
+            end
+        end
+
+        props.optionsList.zIndex = highestZIndex + 1
         optionsContent = e(Roact.Portal, { target = self.props.dockWidget }, {
             OptionsList = e(OptionsList, props.optionsList)
         })

--- a/vibrant/components/ui/ComboBox/init.lua
+++ b/vibrant/components/ui/ComboBox/init.lua
@@ -1,11 +1,13 @@
 local Vibrant = script:FindFirstAncestor("vibrant")
 local Dependencies = require(Vibrant.DependencyPaths)
 local Assets = require(Vibrant.Assets)
+local Dictionary = require(Vibrant.utils.Dictionary)
 local Roact = require(Dependencies.Roact)
 
 local ComboBoxBorder = Assets.ComboBoxBorder
 local ComboBoxBackground = Assets.ComboBoxBackground
 
+local StudioDockWidgetGuiContext = require(Vibrant.components.studio.StudioDockWidgetGuiContext)
 local OptionsList = require(script.OptionsList)
 
 local e = Roact.createElement
@@ -44,16 +46,20 @@ ComboBox.defaultProps = {
 }
 
 function ComboBox:init()
-    self.comboBoxSizeBinding, self.updateComboBoxSize = Roact.createBinding(0)
+    self.comboBoxPositionBinding, self.updateComboBoxPosition = Roact.createBinding(Vector2.new())
+    self.comboBoxSizeBinding, self.updateComboBoxSize = Roact.createBinding(Vector2.new())
     self.isDownArrowHoveredBinding, self.updateIsDownArrowHovered = Roact.createBinding(false)
-    self.isListOpenBinding, self.updateIsListOpen = Roact.createBinding(false)
 
     self.onComboBoxAbsoluteSizeChanged = function(comboBoxBorder)
-        self.updateComboBoxSize(comboBoxBorder.AbsoluteSize.Y)
+        self.updateComboBoxSize(comboBoxBorder.AbsoluteSize)
 
         local downArrowContainer = comboBoxBorder.ComboBoxBackground.DownArrowContainer
         local textContainer = comboBoxBorder.ComboBoxBackground.TextContainer
         textContainer.Size = UDim2.new(UDim.new(1, -downArrowContainer.AbsoluteSize.X), textContainer.Size.Y)
+    end
+
+    self.onComboBoxAbsolutePositionChanged = function(comboBoxBorder)
+        self.updateComboBoxPosition(comboBoxBorder.AbsolutePosition)
     end
 
     self.onTextContainerSizeChanged = function(textContainer)
@@ -75,12 +81,16 @@ function ComboBox:init()
 
     self.onDownArrowContainerMouseClick = function()
         if not self.props.disabled then
-            self.updateIsListOpen(not self.isListOpenBinding:getValue())
+            self:setState({
+                isListOpen = not self.state.isListOpen
+            })
         end
     end
 
     self.onOptionSelected = function(option, index)
-        self.updateIsListOpen(false)
+        self:setState({
+            isListOpen = false
+        })
 
         if type(self.props.onOptionSelected) == "function" then
             self.props.onOptionSelected(option, index)
@@ -100,9 +110,15 @@ function ComboBox:init()
                 return
             end
             
-            self.updateIsListOpen(not self.isListOpenBinding:getValue())
+            self:setState({
+                isListOpen = not self.state.isListOpen
+            })
         end
     end
+
+    self:setState({
+        isListOpen = false
+    })
 end
 
 function ComboBox:render()
@@ -124,14 +140,18 @@ function ComboBox:render()
     local props = {
         optionsList = {
             options = self.props.options,
-            comboBoxSizeBinding = self.comboBoxSizeBinding,
             backgroundColor = self.props.backgroundColor,
             scrollBarColor = self.props.borderColor,
+            size = self.comboBoxSizeBinding,
             textColor = self.props.textColor,
             onOptionSelected = self.onOptionSelected,
-
-            visible = self.isListOpenBinding:map(function(isListOpen)
-                return isListOpen
+            visible = self.state.isListOpen,
+            
+            position = Roact.joinBindings({ self.comboBoxPositionBinding, self.comboBoxSizeBinding }):map(function(values)
+                local absolutePosition = values[1]
+                local absoluteSize = values[2]
+                
+                return UDim2.new(0, absolutePosition.X, 0, absolutePosition.Y + absoluteSize.Y)
             end)
         },
 
@@ -145,7 +165,8 @@ function ComboBox:render()
             SliceCenter = Rect.new(ComboBoxBorder.Slice.Left, ComboBoxBorder.Slice.Top, ComboBoxBorder.Slice.Right, ComboBoxBorder.Slice.Bottom),
             ImageColor3 = borderColor,
 
-            [Roact.Change.AbsoluteSize] = self.onComboBoxAbsoluteSizeChanged
+            [Roact.Change.AbsoluteSize] = self.onComboBoxAbsoluteSizeChanged,
+            [Roact.Change.AbsolutePosition] = self.onComboBoxAbsolutePositionChanged
         },
 
         comboBoxBackground = {
@@ -214,8 +235,16 @@ function ComboBox:render()
         }
     }
 
+    local optionsContent = nil
+    if self.state.isListOpen then
+        optionsContent = e(Roact.Portal, { target = self.props.dockWidget }, {
+            OptionsList = e(OptionsList, props.optionsList)
+        })
+    end
+
     return Roact.createFragment({
-        Options = e(OptionsList, props.optionsList),
+        Options = optionsContent,
+        
         ComboBoxBorder = e("ImageLabel", props.comboBoxBorder, {
             ComboBoxBackground = e("ImageLabel", props.comboBoxBackground, {
                 Padding = e("UIPadding", {
@@ -255,11 +284,22 @@ function ComboBox:render()
     })
 end
 
-function ComboBox:willUpdate(nextProps)
+function ComboBox:willUpdate(nextProps, nextState)
+    -- Not sure if this is the right way to do this? Maybe I need to use getDerivedStateFromProps?
     if nextProps.disabled and nextProps.disabled ~= self.props.disabled then
-        self.updateIsListOpen(false)
+        nextState.isListOpen = false
         self.updateIsDownArrowHovered(false)
     end
 end
 
-return ComboBox
+local function ComboBoxWithDockWidgetContext(props)
+    return e(StudioDockWidgetGuiContext.Consumer, {
+        render = function(dockWidget)
+            return e(ComboBox, Dictionary.merge(props, {
+                dockWidget = dockWidget
+            }))
+        end
+    })
+end
+
+return ComboBoxWithDockWidgetContext


### PR DESCRIPTION
Combo box lists are now parented to the top level dock widget with the highest z-index so they render over everything else in the dock widget.